### PR TITLE
Add support for TP subdomain

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,22 @@
             ],
             "internalConsoleOptions": "openOnSessionStart",
             "console": "integratedTerminal"
-        }
+        }, 
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "List twotime",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}\\bin\\index.js",
+            "args": [ "list" ],
+            "preLaunchTask": "${defaultBuildTask}",
+            "outFiles": [
+                "${workspaceFolder}/bin/**/*.js"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "console": "integratedTerminal"
+        }, 
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Launch twotime",
+            "name": "twotime start",
             "skipFiles": [
                 "<node_internals>/**"
             ],
@@ -23,12 +23,28 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "List twotime",
+            "name": "twotime list",
             "skipFiles": [
                 "<node_internals>/**"
             ],
             "program": "${workspaceFolder}\\bin\\index.js",
             "args": [ "list" ],
+            "preLaunchTask": "${defaultBuildTask}",
+            "outFiles": [
+                "${workspaceFolder}/bin/**/*.js"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "console": "integratedTerminal"
+        }, 
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "twotime auth",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}\\bin\\index.js",
+            "args": [ "auth" ],
             "preLaunchTask": "${defaultBuildTask}",
             "outFiles": [
                 "${workspaceFolder}/bin/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,6 +51,6 @@
             ],
             "internalConsoleOptions": "openOnSessionStart",
             "console": "integratedTerminal"
-        }, 
+        }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,22 @@
             "problemMatcher": [
                 "$tsc"
             ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "npm",
+            "script": "build-test",
             "group": "build"
+        },
+        {
+            "type": "npm",
+            "script": "lint",
+            "problemMatcher": [
+                "$eslint-stylish"
+            ]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,15 @@
             "problemMatcher": [
                 "$eslint-stylish"
             ]
+        },
+        {
+            "type": "typescript",
+            "tsconfig": "tsconfig.json",
+            "option": "watch",
+            "problemMatcher": [
+                "$tsc-watch"
+            ],
+            "group": "build"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,8 +16,11 @@
         },
         {
             "type": "npm",
-            "script": "build-test",
-            "group": "build"
+            "script": "test",
+            "group": "build",
+            "problemMatcher": [
+                "$tsc"
+            ]
         },
         {
             "type": "npm",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,16 +8,12 @@ trigger:
   branches:
     include:
       - master
-      - develop
-      - release/*
 
 pr:
   autoCancel: true
   branches:
     include:
       - master
-      - develop
-      - release/*
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -28,9 +24,14 @@ steps:
     versionSpec: '10.x'
   displayName: 'Install Node.js'
 
-- script: |
-    npm install
-    npm run lint
-    npm run build
-    npm run test
-  displayName: 'npm install, lint, build and test'
+- script: npm install
+  displayName: 'npm install'
+
+- script: npm run lint
+  displayName: 'linting'
+
+- script: npm run build
+  displayName: 'building'
+
+- script: npm run test
+  displayName: 'run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,20 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- master
+  batch: true
+  branches:
+    include:
+      - master
+      - develop
+      - release/*
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - master
+      - develop
+      - release/*
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -17,5 +30,7 @@ steps:
 
 - script: |
     npm install
+    npm run lint
     npm run build
-  displayName: 'npm install and build'
+    npm run test
+  displayName: 'npm install, lint, build and test'

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -40,7 +40,7 @@ export class ApiProvider {
 
         const config = this.getHarvestConfig();
 
-        if (config === null || config.accessToken == null || config.accountId == null) {
+        if (config === null || config.accessToken === null || config.accountId === null) {
             log.error("Harvest authentication not configured correctly.");
             log.error("Use `twotime auth` to authenticate.");
             process.exit(1);

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -113,7 +113,7 @@ export class ApiProvider {
         }
 
         if (config.subdomain !== "neworbit") {
-            log.warn(`twotime is currently configured for non-neworbit TP subdomain, '${config.subdomain}'`);
+            log.warn(`twotime is currently configured for non-NewOrbit TP subdomain, '${config.subdomain}'`);
         }
 
         return config as TargetprocessConfig;

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -8,7 +8,7 @@ interface HarvestConfig {
     accountId: number;
 }
 
-interface TargetprocessConfig {
+export interface TargetprocessConfig {
     username: string;
     password: string;
     subdomain: string;
@@ -25,8 +25,9 @@ export class ApiProvider {
     private harvestApi: HarvestApi;
     private targetprocessApi: Targetprocess;
 
-    constructor() {
-        this.store = new Configstore(CONFIG_KEYS.TWOTIME);
+    // An optional DI makes testing a little easier.
+    constructor(store?: Configstore) {
+        this.store = store || new Configstore(CONFIG_KEYS.TWOTIME);
         log.info(`Getting config from ${this.store.path}`);
 
         this.harvestApi = null;
@@ -73,19 +74,11 @@ export class ApiProvider {
         return this.targetprocessApi;
     }
 
-    public setHarvestConfig(accessToken: string, accountId: number, ) {
-        const config: HarvestConfig = {
-            accessToken, accountId
-        };
-
+    public setHarvestConfig(config: HarvestConfig) {
         this.store.set(CONFIG_KEYS.HARVEST, config);
     }
 
-    public setTargetprocessConfig(username: string, password: string, subdomain: string) {
-        const config: TargetprocessConfig = {
-            username, password, subdomain
-        };
-
+    public setTargetprocessConfig(config: TargetprocessConfig) {
         this.store.set(CONFIG_KEYS.TARGETPROCESS, config);
     }
 
@@ -100,6 +93,7 @@ export class ApiProvider {
     }
 
     private getTargetprocessConfig() {
+        const defaultSubdomain = "neworbit";
         const config = this.store.get(CONFIG_KEYS.TARGETPROCESS);
         if (!config) {
             return null;
@@ -107,12 +101,12 @@ export class ApiProvider {
 
         // Existing configs won't have subdomain setting, so put it there with existing default.
         if (!config.subdomain) {
-            config.subdomain = "neworbit";
+            config.subdomain = defaultSubdomain;
             log.info(`Setting TargetProcess to default TP subdomain, '${config.subdomain}'`);
-            this.setTargetprocessConfig(config.username, config.password, config.subdomain);
+            this.setTargetprocessConfig(config);
         }
 
-        if (config.subdomain !== "neworbit") {
+        if (config.subdomain !== defaultSubdomain) {
             log.warn(`twotime is currently configured for non-NewOrbit TP subdomain, '${config.subdomain}'`);
         }
 

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -60,7 +60,7 @@ export class ApiProvider {
 
         const { username, password, subdomain } = this.getTargetprocessConfig();
 
-        if (username == null || password == null || subdomain == null) {
+        if (username === null || password === null || subdomain === null) {
             log.error("Targetprocess authentication not configured correctly.");
             log.error("Use `twotime auth` to authenticate.");
             process.exit(1);

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -105,7 +105,7 @@ export class ApiProvider {
             return null;
         }
 
-        // Existing clients won't have subdomain in config, so put it there with existing default.
+        // Existing configs won't have subdomain setting, so put it there with existing default.
         if (!config.subdomain) {
             config.subdomain = "neworbit";
             log.info(`Setting TargetProcess to default TP subdomain, '${config.subdomain}'`);

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -112,7 +112,7 @@ export class ApiProvider {
             this.setTargetprocessConfig(config.username, config.password, config.subdomain);
         }
 
-        if (config.subdomain != "neworbit") {
+        if (config.subdomain !== "neworbit") {
             log.warn(`twotime is currently configured for non-neworbit TP subdomain, '${config.subdomain}'`);
         }
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -7,11 +7,12 @@ export const auth = async (apiProvider: ApiProvider) => {
         harvestAccessToken,
         harvestAccountId,
         targetprocessUsername,
-        targetprocessPassword
+        targetprocessPassword,
+        targetprocessSubdomain
     } = await askAuthDetails();
 
     apiProvider.setHarvestConfig(harvestAccessToken, harvestAccountId);
-    apiProvider.setTargetprocessConfig(targetprocessUsername, targetprocessPassword);
+    apiProvider.setTargetprocessConfig(targetprocessUsername, targetprocessPassword, targetprocessSubdomain);
 
     log.info("Authentication complete.");
 };

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -11,8 +11,8 @@ export const auth = async (apiProvider: ApiProvider) => {
         targetprocessSubdomain
     } = await askAuthDetails();
 
-    apiProvider.setHarvestConfig(harvestAccessToken, harvestAccountId);
-    apiProvider.setTargetprocessConfig(targetprocessUsername, targetprocessPassword, targetprocessSubdomain);
+    apiProvider.setHarvestConfig({ accessToken: harvestAccessToken, accountId: harvestAccountId });
+    apiProvider.setTargetprocessConfig({username: targetprocessUsername, password: targetprocessPassword, subdomain: targetprocessSubdomain });
 
     log.info("Authentication complete.");
 };

--- a/src/commands/prompts/auth.ts
+++ b/src/commands/prompts/auth.ts
@@ -8,7 +8,8 @@ export const askAuthDetails = async () => {
         harvestAccessToken: string,
         harvestAccountId: number,
         targetprocessUsername: string,
-        targetprocessPassword: string
+        targetprocessPassword: string,
+        targetprocessSubdomain: string
     }>([{
         name: "harvestAccessToken",
         message: "What is your Harvest access token?",
@@ -27,5 +28,10 @@ export const askAuthDetails = async () => {
         message: "What is your Targetprocess password?",
         validate: notEmpty,
         type: "password"
+    }, {
+        name: "targetprocessSubdomain",
+        message: "What is your Targetprocess subdomain (e.g. 'neworbit')?",
+        validate: notEmpty,
+        default: "neworbit"
     }]);
 };

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -19,11 +19,10 @@ export const start = async (packageVersion: string, apiProvider: ApiProvider, da
 
     log.info("Starting Harvest timer...");
     try {
-        await harvestApi.startTimeEntry(details.projectId, details.taskId, date, notes, details.hours, details.running)
-    }
-    catch(e) {
+        await harvestApi.startTimeEntry(details.projectId, details.taskId, date, notes, details.hours, details.running);
+    } catch (e) {
         log.error(e);
     }
-    
-    log.info("> Timer started"); 
+
+    log.info("> Timer started");
 };

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -6,6 +6,7 @@ import mapValues = require("lodash.mapvalues");
 
 export const log = {
     error: (message: string) => console.log(chalk.red("[ERROR] ") + message),
+    warn: (message: string) => console.log(chalk.yellow("[WARN] ") + message),
     info: (message: string) => console.log(chalk.cyan("[INFO] ") + message),
     table: (headers: string[], rows: string[][]) => {
         const data = [

--- a/test/api/tp-sub-domains.test.ts
+++ b/test/api/tp-sub-domains.test.ts
@@ -1,0 +1,34 @@
+import { TestFixture, TestCase, Expect } from "alsatian";
+import { ApiProvider, TargetprocessConfig } from "../../src/api-provider";
+
+@TestFixture()
+export class TargetProcessApiTests {
+    private fakeStore = {
+        get: () => {
+            return {
+                subdomain: this.tpConfig.subdomain
+            };
+        },
+        set: (key: string, config: TargetprocessConfig) => {
+            this.tpConfig = config;
+        }
+    };
+
+    private tpConfig: TargetprocessConfig;
+
+    @TestCase(undefined, null, null)
+    @TestCase("neworbit", null, null)
+    @TestCase("notneworbit", null, null)
+    public subdomainShouldBeBackwardsCompatible(subdomain: string, username: string, password: string) {
+        this.tpConfig = { username, password, subdomain };
+        const apiProvider = new ApiProvider(this.fakeStore as any);
+        const tpApi = apiProvider.getTargetprocessApi();
+
+        if (!!subdomain) {
+            Expect(this.tpConfig.subdomain).toBe(subdomain);
+        } else {
+            Expect(this.tpConfig.subdomain).toBeTruthy();
+            Expect(this.tpConfig.subdomain).toBe("neworbit");
+        }
+    }
+}


### PR DESCRIPTION
Added the ability to specify a subdomain other than "`neworbit`" for the targetprocess API (e.g. "`getsymphony`", "`ttc`") because I want to track my time using `twotime` but Symphony (https://www.whysymphony.com/) are using their own TP instance.